### PR TITLE
MOB-1699: Can't use server url with http redirection

### DIFF
--- a/Sources/Shared/Components/eXoUtils/URLAnalyzer.h
+++ b/Sources/Shared/Components/eXoUtils/URLAnalyzer.h
@@ -28,5 +28,6 @@
 + (BOOL)      isIPAddress:(NSString *)urlStr;
 + (NSString *)enCodeURL:(NSString *)url;
 + (NSString *)decodeURL:(NSString *)url;
++ (NSString *)extractDomainFromURL:(NSString *)urlStr;
 
 @end

--- a/Sources/Shared/Components/eXoUtils/URLAnalyzer.m
+++ b/Sources/Shared/Components/eXoUtils/URLAnalyzer.m
@@ -99,6 +99,15 @@
     return result;
 }
 
++ (NSString*) extractDomainFromURL:(NSString *)urlStr {
+    NSURL* url = [NSURL URLWithString:urlStr];
+    if (url && url.scheme && url.host) {
+        return [NSString stringWithFormat:@"%@://%@", url.scheme, url.host];
+    } else {
+        return @"";
+    }
+}
+
 + (NSString *)enCodeURL:(NSString *)url {
     
     NSMutableString *escaped = [NSMutableString stringWithString:url];  

--- a/Tests/URLAnalyzerTestCase.m
+++ b/Tests/URLAnalyzerTestCase.m
@@ -95,4 +95,39 @@
     }
 }
 
+- (void)testExtractDomainFromURL_Success
+{
+    // http
+    NSArray* urls = @[
+                      @"http://community.exoplatform.com/a/path",
+                      @"http://community.exoplatform.com/",
+                      @"http://community.exoplatform.com"
+                      ];
+    for (NSString* url in urls) {
+        XCTAssertEqualObjects([URLAnalyzer extractDomainFromURL:url],
+                              @"http://community.exoplatform.com",
+                              @"Failed to extract domain from URL %@", url);
+    }
+    
+    // https
+    NSString* urlHttps = @"https://community.exoplatform.com/a/path";
+    XCTAssertEqualObjects([URLAnalyzer extractDomainFromURL:urlHttps],
+                          @"https://community.exoplatform.com",
+                          @"Failed to extract domain from URL %@", urlHttps);
+}
+
+- (void)testExtractDomainFromURL_Failure
+{
+    NSArray* urls = @[
+                      @"community.exoplatform.com/rest/private",
+                      @"",
+                      @"null"
+                      ];
+    for (NSString* url in urls) {
+        XCTAssertEqualObjects([URLAnalyzer extractDomainFromURL:url],
+                              @"",
+                              @"Domain extraction from %@ should have failed and returned an empty string", url);
+    }
+}
+
 @end


### PR DESCRIPTION
Solution:
-    Using the delegate method from NSURLConnection, we can intercept the initial response *before* the new request is sent
-    This response contains the new URL in the Location header
-    We get this URL, retrieve only the domain, and save this value in the current account.
