### PR TITLE
MOB-1794 Apply scroll to top on the table-views

### DIFF
--- a/Sources/Shared/Components/eXoUtils/defines.h
+++ b/Sources/Shared/Components/eXoUtils/defines.h
@@ -52,7 +52,9 @@
 #define EXO_NOTIFICATION_SHOW_PRIVATE_DRIVE @"notification-show-private-drive"
 #define EXO_NOTIFICATION_SERVER_ADDED       @"notification-server-added"
 #define EXO_NOTIFICATION_SERVER_DELETED     @"notification-server-deleted"
+#define EXO_NOTIFICATION_SCROLL_TO_TOP      @"notification-table-view-scroll-to-top"
 
+#define EXO_TABLEVIEW_ORIGIN_POINT          CGPointMake(0,-35)
 #define EXO_PREFERENCE_LANGUAGE				@"language"
 #define HTTP_PROTOCOL                       @"http://"
 #define HTTPS_PROTOCOL                       @"https://"

--- a/Sources/Shared/Components/eXoUtils/eXoViewController.h
+++ b/Sources/Shared/Components/eXoUtils/eXoViewController.h
@@ -29,6 +29,10 @@
 
 @property (nonatomic, retain) IBOutlet UINavigationBar* navigation;
 @property (nonatomic, retain) UILabel* label;
+@property (nonatomic, retain) UIButton* topViewButton;
+
+-(void) scrollTableViewToTop:(id) sender;
+
 // ATMHud to manage loading diplay
 @property (nonatomic, readonly) ATMHud *hudLoadWaiting;
 

--- a/Sources/Shared/Components/eXoUtils/eXoViewController.m
+++ b/Sources/Shared/Components/eXoUtils/eXoViewController.m
@@ -24,13 +24,21 @@
 
 @synthesize hudLoadWaiting = _hudLoadWaiting;
 @synthesize navigation = _navigation, label;
-
+@synthesize topViewButton;
 #pragma mark - View lifecycle
 // Implement viewDidLoad to do additional setup after loading the view, typically from a nib.
 - (void)viewDidLoad
 {
     [super viewDidLoad];
+    topViewButton = [[[UIButton alloc] initWithFrame:CGRectMake(100,0,_navigation.frame.size.width-200,20)] autorelease];
+    [topViewButton addTarget:self action:@selector(scrollTableViewToTop:) forControlEvents:UIControlEventTouchUpInside];
+    topViewButton.backgroundColor = [UIColor clearColor];
+    [_navigation addSubview:topViewButton];
+    
     self.view.backgroundColor = [UIColor colorWithPatternImage:[UIImage imageNamed:@"bgGlobal.png"]];
+}
+
+-(void) scrollTableViewToTop:(id) sender {
 }
 
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation

--- a/Sources/iPad/View Controllers/File/DocumentsViewController_iPad.m
+++ b/Sources/iPad/View Controllers/File/DocumentsViewController_iPad.m
@@ -65,6 +65,10 @@
     _navigation.titleTextAttributes = @{NSForegroundColorAttributeName: [UIColor whiteColor]};
 }
 
+-(void) scrollTableViewToTop:(id) sender {
+    [self.tblFiles setContentOffset:EXO_TABLEVIEW_ORIGIN_POINT animated:YES];
+}
+
 - (CGRect)rectOfHeader:(int)width
 {
     return CGRectMake(50.0, 11.0, width, kHeightForSectionHeader);

--- a/Sources/iPad/View Controllers/Social/ActivityDetailViewController_iPad.m
+++ b/Sources/iPad/View Controllers/Social/ActivityDetailViewController_iPad.m
@@ -62,6 +62,12 @@
     self.tblvActivityDetail.backgroundView = [[[CustomBackgroundView alloc] initWithFrame:CGRectZero] autorelease];
     _navigation.topItem.title = Localize(@"Details");
     _navigation.titleTextAttributes = @{NSForegroundColorAttributeName: [UIColor whiteColor]};
+ 
+    
+}
+
+-(void) scrollTableViewToTop:(id) sender {
+    [self.tblvActivityDetail setContentOffset:EXO_TABLEVIEW_ORIGIN_POINT animated:YES];
 }
 
 #pragma mark - like/dislike management

--- a/Sources/iPad/View Controllers/Social/ActivityStreamBrowseViewController_iPad.m
+++ b/Sources/iPad/View Controllers/Social/ActivityStreamBrowseViewController_iPad.m
@@ -54,6 +54,10 @@
     [self.view addSubview:self.hudLoadWaitingWithPositionUpdated.view];
 }
 
+-(void) scrollTableViewToTop:(id) sender {
+    [self.tblvActivityStream setContentOffset:EXO_TABLEVIEW_ORIGIN_POINT animated:YES];
+}
+
 // Specific method to retrieve the height of the cell
 // This method override the inherited one.
 - (float)getHeighSizeForTableView:(UITableView *)tableView andText:(NSString*)text  picture:(BOOL)isPicture

--- a/Sources/iPhone/View Controllers/Main/DocumentsViewController_iPhone.m
+++ b/Sources/iPhone/View Controllers/Main/DocumentsViewController_iPhone.m
@@ -46,6 +46,8 @@
 
 - (void)dealloc
 {
+    [[NSNotificationCenter defaultCenter]removeObserver:self name:EXO_NOTIFICATION_SCROLL_TO_TOP object:nil];
+    
     [super dealloc];
 }
 
@@ -82,6 +84,8 @@
     CGRect tmpFrame = [[UIScreen mainScreen] bounds];
     tmpFrame.size.height -= 44; // navigation bar size. 
     self.tblFiles.frame = tmpFrame;
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(scrollToTopNotificationHandle) name:EXO_NOTIFICATION_SCROLL_TO_TOP object:nil];
 }
 
 - (void)viewDidAppear:(BOOL)animated {
@@ -111,6 +115,11 @@
 
 
 #pragma mark - UINavigationBar Management
+-(void) scrollToTopNotificationHandle {
+    if (self.view.window){
+        [self.tblFiles setContentOffset:EXO_TABLEVIEW_ORIGIN_POINT animated:YES];
+    }
+}
 
 - (void)setTitleForFilesViewController {
     if (_rootFile) {

--- a/Sources/iPhone/View Controllers/Main/HomeSidebarViewController_iPhone.m
+++ b/Sources/iPhone/View Controllers/Main/HomeSidebarViewController_iPhone.m
@@ -264,6 +264,19 @@
     [self.view addSubview:_revealView];
     
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(updateLabelsWithNewLanguage) name:EXO_NOTIFICATION_CHANGE_LANGUAGE object:nil];
+    
+    UIButton *topScrollButton = [[UIButton buttonWithType:UIButtonTypeCustom] autorelease];
+    topScrollButton.frame = CGRectMake(self.view.center.x - 50, 0, 100,20);
+    [topScrollButton addTarget:self action:@selector(topScrollButtonAction:) forControlEvents: UIControlEventTouchUpInside];
+    topScrollButton.backgroundColor = [UIColor clearColor];
+    [self.view addSubview:topScrollButton];
+    
+}
+
+-(void) topScrollButtonAction:(id) sender {
+    if (! [_revealView isSidebarShowing]){
+            [[NSNotificationCenter defaultCenter] postNotificationName:EXO_NOTIFICATION_SCROLL_TO_TOP object:nil];
+        }
 }
 
 - (void)setAccountSwitcherVisibility

--- a/Sources/iPhone/View Controllers/Social/ActivityDetailViewController_iPhone.m
+++ b/Sources/iPhone/View Controllers/Social/ActivityDetailViewController_iPhone.m
@@ -44,6 +44,7 @@
 - (void)dealloc {
     [_noCommentCell release];
     [_likeViewCell release];
+    [[NSNotificationCenter defaultCenter]removeObserver:self name:EXO_NOTIFICATION_SCROLL_TO_TOP object:nil];
     [super dealloc];
 }
 
@@ -92,8 +93,13 @@
     [_btnMsgComposer setBackgroundImage:strechBg forState:UIControlStateNormal];
     [_btnMsgComposer setTitleEdgeInsets:UIEdgeInsetsMake(5.0f, 0.0f, 0.0f, 0.0f)];
     [_btnMsgComposer setTitle:Localize(@"YourComment") forState:UIControlStateNormal];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(scrollToTopNotificationHandle) name:EXO_NOTIFICATION_SCROLL_TO_TOP object:nil];
+    
 }
-
+- (void) scrollToTopNotificationHandle {
+    if (self.view.window)
+        [self.tblvActivityDetail setContentOffset:EXO_TABLEVIEW_ORIGIN_POINT animated:YES];
+}
 
 - (void)onBtnMessageComposer
 {

--- a/Sources/iPhone/View Controllers/Social/ActivityStreamBrowseViewController_iPhone.m
+++ b/Sources/iPhone/View Controllers/Social/ActivityStreamBrowseViewController_iPhone.m
@@ -66,10 +66,15 @@
     
     [AppDelegate_iPhone instance].homeSidebarViewController_iPhone.contentNavigationItem.rightBarButtonItem = self.navigationItem.rightBarButtonItem;
     [AppDelegate_iPhone instance].homeSidebarViewController_iPhone.contentNavigationBar.titleTextAttributes = @{NSForegroundColorAttributeName: [UIColor whiteColor]};
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(scrollToTopNotificationHandle) name:EXO_NOTIFICATION_SCROLL_TO_TOP object:nil];
 }
-
-
-
+-(void) scrollToTopNotificationHandle {
+        [self.tblvActivityStream setContentOffset:EXO_TABLEVIEW_ORIGIN_POINT animated:YES];
+}
+-(void) dealloc {
+    [[NSNotificationCenter defaultCenter]removeObserver:self name:EXO_NOTIFICATION_SCROLL_TO_TOP object:nil];
+    [super dealloc];
+}
 
 - (void)postACommentOnActivity:(NSString *)activity {
     MessageComposerViewController_iPhone* messageComposerViewController = [[MessageComposerViewController_iPhone alloc] initWithNibName:@"MessageComposerViewController_iPhone" bundle:nil];


### PR DESCRIPTION
Add feature Possibility to scroll to top on the tables view by touching the top area on the navigation bar.
Implemented Solution 
- iPad: 
   + A button size as a normal status bar (height = 20) to all navigation bar, Every View Controller which has a tableview override the action for event touch up inside of this button. 
- iPhone:
 + All View Controllers in iPhone share the same Navigation Bar. So a button (size = status bar size) is added to the Bar, each time, the button is touched up inside a notification will be post. The View Controller which has a tableview catch this notification. 

- Note: the origin offset point of the tableview controller is: (0,-35) (see in define.h) 

