### PR TITLE
MOB-1873 Use ARC for DashBoard VC (& DashBoard VC for iPhone/iPad)

### DIFF
--- a/Sources/Shared/UI/Dashboard/DashboardViewController.m
+++ b/Sources/Shared/UI/Dashboard/DashboardViewController.m
@@ -62,30 +62,7 @@
 
 - (void)dealloc
 {
-    [_arrDashboard release];
-	_arrDashboard = nil;
-    
-    _tblGadgets = nil;
-    
-    [_refreshHeaderView release];
-    _refreshHeaderView = nil;
-    
-    [_dateOfLastUpdate release];
-    _dateOfLastUpdate = nil;
-    
-    [_refreshHeaderView release];
-    _refreshHeaderView = nil;
-    
-    _dashboardProxy.delegate = nil;
-    [_dashboardProxy release];
-    _dashboardProxy = nil;
-    
-    [_errorForRetrievingDashboard release];
-    _errorForRetrievingDashboard = nil;
-    
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-    
-    [super dealloc];
+    [[NSNotificationCenter defaultCenter] removeObserver:self];    
 }
 
 - (void)didReceiveMemoryWarning
@@ -103,8 +80,6 @@
 {
     [super viewDidLoad];
     
-    //Reset the  content of the view 
-    [_arrDashboard release];
     self.view.backgroundColor = EXO_BACKGROUND_COLOR;
     
     // Do any additional setup after loading the view from its nib.
@@ -135,7 +110,6 @@
 		view.delegate = self;
 		[_tblGadgets addSubview:view];
 		_refreshHeaderView = view;
-		[view release];
         _reloading = FALSE;
         
 	}
@@ -148,7 +122,6 @@
 
 - (void)viewDidUnload
 {
-    [_refreshHeaderView release]; _refreshHeaderView =nil;
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     [super viewDidUnload];
     // Release any retained subviews of the main view.
@@ -165,7 +138,6 @@
         EmptyView *emptyView = [[EmptyView alloc] initWithFrame:self.view.bounds withImageName:@"IconForNoGadgets.png" andContent:Localize(@"NoGadget")];
         emptyView.tag = TAG_EMPTY;
         [self.view insertSubview:emptyView belowSubview:_tblGadgets];
-        [emptyView release];        
     } else {
         [[self.view viewWithTag:TAG_EMPTY] removeFromSuperview];
     }
@@ -179,7 +151,6 @@
     //add empty view to the view 
     EmptyView *emptyView = [[EmptyView alloc] initWithFrame:self.view.bounds withImageName:@"IconForNoGadgets.png" andContent:Localize(@"NoGadget")];
     [self.view insertSubview:emptyView aboveSubview:_tblGadgets];
-    [emptyView release];
 }
 
 
@@ -245,7 +216,6 @@
 {
     return kHeightForSectionHeader;
 }
-
 - (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
 {
 	
@@ -279,10 +249,8 @@
     imgVBackground.frame = CGRectMake(headerLabel.frame.origin.x - 10, 16.0, theSize.width + 30, kHeightForSectionHeader-15);
     
 	[customView addSubview:imgVBackground];
-    [imgVBackground release];
     
     [customView addSubview:headerLabel];
-    [headerLabel release];
     
 	return customView;
 }
@@ -371,11 +339,11 @@
         NSString *alertMessage = [NSString stringWithFormat:@"%@: %@, %@",Localize(@"Dashboard"),_errorForRetrievingDashboard,Localize(@"GadgetsCannotBeRetrieved")];
         
         //Display an UIAlert to the user
-        UIAlertView* alertView = [[[UIAlertView alloc] initWithTitle:Localize(@"Error") 
+        UIAlertView* alertView = [[UIAlertView alloc] initWithTitle:Localize(@"Error")
                                                              message:alertMessage 
                                                             delegate:self 
                                                    cancelButtonTitle:Localize(@"OK") 
-                                                   otherButtonTitles:nil] autorelease];
+                                                   otherButtonTitles:nil];
         
         [alertView show];
     }
@@ -393,11 +361,11 @@
     
     
     //Display an UIAlert to the user
-    UIAlertView* alertView = [[[UIAlertView alloc] initWithTitle:Localize(@"Error") 
+    UIAlertView* alertView = [[UIAlertView alloc] initWithTitle:Localize(@"Error")
                                                          message:Localize(@"DashboardsCannotBeRetrieved") 
                                                         delegate:self 
                                                cancelButtonTitle:Localize(@"OK") 
-                                               otherButtonTitles:nil] autorelease];
+                                               otherButtonTitles:nil];
     
     [alertView show];
 }

--- a/Sources/iPad/View Controllers/Main/DashboardViewController_iPad.m
+++ b/Sources/iPad/View Controllers/Main/DashboardViewController_iPad.m
@@ -55,7 +55,7 @@
     GadgetItem* gadgetTmp = [(DashboardItem *)_arrDashboard[indexPath.section] arrayOfGadgets][indexPath.row]; 
 
     
-    GadgetDisplayViewController_iPad* gadgetDisplayViewController = [[[GadgetDisplayViewController_iPad alloc] initWithNibAndUrl:@"GadgetDisplayViewController_iPad" bundle:nil gadget:gadgetTmp] autorelease];
+    GadgetDisplayViewController_iPad* gadgetDisplayViewController = [[GadgetDisplayViewController_iPad alloc] initWithNibAndUrl:@"GadgetDisplayViewController_iPad" bundle:nil gadget:gadgetTmp];
     
     // push the gadgets
     [[AppDelegate_iPad instance].rootViewController.stackScrollViewController addViewInSlider:gadgetDisplayViewController invokeByController:self isStackStartView:FALSE];

--- a/Sources/iPhone/View Controllers/Main/DashboardViewController_iPhone.m
+++ b/Sources/iPhone/View Controllers/Main/DashboardViewController_iPhone.m
@@ -63,7 +63,7 @@
     
     GadgetItem* gadgetTmp = [(DashboardItem *)_arrDashboard[indexPath.section] arrayOfGadgets][indexPath.row]; 
 
-	GadgetDisplayViewController_iPhone* gadgetDisplayViewController = [[[GadgetDisplayViewController_iPhone alloc] initWithNibAndUrl:@"GadgetDisplayViewController_iPhone"  bundle:nil gadget:gadgetTmp] autorelease];
+    GadgetDisplayViewController_iPhone* gadgetDisplayViewController = [[GadgetDisplayViewController_iPhone alloc] initWithNibAndUrl:@"GadgetDisplayViewController_iPhone"  bundle:nil gadget:gadgetTmp];
 
     //[self.navigationController pushViewController:gadgetDisplayViewController animated:YES];
     [[AppDelegate_iPhone instance].homeSidebarViewController_iPhone  pushViewController:gadgetDisplayViewController animated:YES];

--- a/eXo.xcodeproj/project.pbxproj
+++ b/eXo.xcodeproj/project.pbxproj
@@ -222,7 +222,7 @@
 		46ABBE8A13890C260077809B /* File.m in Sources */ = {isa = PBXBuildFile; fileRef = 46ABBE8913890C260077809B /* File.m */; };
 		46ABBE95138914200077809B /* DocumentsViewController_iPhone.m in Sources */ = {isa = PBXBuildFile; fileRef = 46ABBE931389141F0077809B /* DocumentsViewController_iPhone.m */; };
 		46ADAEE11406881B005ABA79 /* ActivityStreamBrowseViewController_iPhone.xib in Resources */ = {isa = PBXBuildFile; fileRef = 46ADAEE014068819005ABA79 /* ActivityStreamBrowseViewController_iPhone.xib */; };
-		46ADAEE514068EAF005ABA79 /* DashboardViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 46ADAEE414068EAF005ABA79 /* DashboardViewController.m */; };
+		46ADAEE514068EAF005ABA79 /* DashboardViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 46ADAEE414068EAF005ABA79 /* DashboardViewController.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		46BE69DB13D5B30E00F62614 /* SocialComment.m in Sources */ = {isa = PBXBuildFile; fileRef = 46BE69D413D5B30E00F62614 /* SocialComment.m */; };
 		46BE69E013D5B33E00F62614 /* SocialPostActivity.m in Sources */ = {isa = PBXBuildFile; fileRef = 46BE69DF13D5B33E00F62614 /* SocialPostActivity.m */; };
 		46BE69E313D5B38300F62614 /* SocialActivityDetailsProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 46BE69E213D5B38300F62614 /* SocialActivityDetailsProxy.m */; };
@@ -435,12 +435,12 @@
 		7C34684513C2DB770030DC23 /* ActivityStreamBrowseViewController_iPhone.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C34683F13C2DB770030DC23 /* ActivityStreamBrowseViewController_iPhone.m */; };
 		7C34684613C2DB770030DC23 /* MessageComposerViewController_iPhone.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C34684113C2DB770030DC23 /* MessageComposerViewController_iPhone.m */; };
 		7C34684713C2DB770030DC23 /* MessageComposerViewController_iPhone.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7C34684213C2DB770030DC23 /* MessageComposerViewController_iPhone.xib */; };
-		7C3BD1A21370FE1700380828 /* DashboardViewController_iPad.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C3BD19B1370FE1700380828 /* DashboardViewController_iPad.m */; };
+		7C3BD1A21370FE1700380828 /* DashboardViewController_iPad.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C3BD19B1370FE1700380828 /* DashboardViewController_iPad.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		7C3DF00613F1212700640BDB /* PhotoActionViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7C3DF00513F1212700640BDB /* PhotoActionViewController.xib */; };
 		7C3DF00913F1217200640BDB /* PhotoActionViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C3DF00813F1217100640BDB /* PhotoActionViewController.m */; };
 		7C5053EC13E2AF3600FA73CD /* default-avatar.png in Resources */ = {isa = PBXBuildFile; fileRef = 7C5053EA13E2AF3600FA73CD /* default-avatar.png */; };
 		7C5053ED13E2AF3600FA73CD /* default-avatar@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 7C5053EB13E2AF3600FA73CD /* default-avatar@2x.png */; };
-		7C57648A1368032800C5F028 /* DashboardViewController_iPhone.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C5764871368032800C5F028 /* DashboardViewController_iPhone.m */; };
+		7C57648A1368032800C5F028 /* DashboardViewController_iPhone.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C5764871368032800C5F028 /* DashboardViewController_iPhone.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		7CA74B1213C30C330006306D /* ActivityDetailViewController_iPad.m in Sources */ = {isa = PBXBuildFile; fileRef = 7CA74B0B13C30C330006306D /* ActivityDetailViewController_iPad.m */; };
 		7CA74B1313C30C330006306D /* ActivityDetailViewController_iPad.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7CA74B0C13C30C330006306D /* ActivityDetailViewController_iPad.xib */; };
 		7CA74B1413C30C330006306D /* ActivityStreamBrowseViewController_iPad.m in Sources */ = {isa = PBXBuildFile; fileRef = 7CA74B0E13C30C330006306D /* ActivityStreamBrowseViewController_iPad.m */; };
@@ -1689,8 +1689,6 @@
 		9CE6E3EE1B01DDB700B2EA36 /* ActivityForumTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ActivityForumTableViewCell.xib; sourceTree = "<group>"; };
 		9CE6E3F01B01E02800B2EA36 /* ActivityForumDetailMessageTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = ActivityForumDetailMessageTableViewCell.xib; path = Social/ActivityForumDetailMessageTableViewCell.xib; sourceTree = "<group>"; };
 		9CF1F7621ADB827300E89909 /* libPods-eXo-RestKit.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libPods-eXo-RestKit.a"; path = "Pods/../build/Debug-iphoneos/libPods-eXo-RestKit.a"; sourceTree = "<group>"; };
-		9CFED9081B3ABFE70049B9CC /* eXo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = eXo.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		9CFED90A1B3ABFE70049B9CC /* eXoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = eXoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9CFED90B1B3AC57D0049B9CC /* Fabric.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Fabric.framework; sourceTree = "<group>"; };
 		A60C63C6152968F900F5A52A /* ImagePreviewViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ImagePreviewViewController.h; path = Social/ImagePreviewViewController.h; sourceTree = "<group>"; };
 		A60C63C7152968FA00F5A52A /* ImagePreviewViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ImagePreviewViewController.m; path = Social/ImagePreviewViewController.m; sourceTree = "<group>"; };


### PR DESCRIPTION
- The reason the the Crash in the Dashboard VC is a method release was sent to the header (or its sub views) when the header after the dealloc. So the solution proposed here is apply ARC for this Views Controller. 