### PR TITLE
MOB-1935 Fix bugs in share extension by free un-use memory after upload

### DIFF
--- a/share-extension/Info.plist
+++ b/share-extension/Info.plist
@@ -39,6 +39,8 @@
 		<dict>
 			<key>NSExtensionActivationRule</key>
 			<dict>
+				<key>NSExtensionActivationSupportsAttachmentsWithMaxCount</key>
+				<string>10</string>
 				<key>NSExtensionActivationSupportsFileWithMaxCount</key>
 				<integer>10</integer>
 				<key>NSExtensionActivationSupportsImageWithMaxCount</key>

--- a/share-extension/ShareViewController.m
+++ b/share-extension/ShareViewController.m
@@ -685,11 +685,13 @@ NSMutableData * data;
                         uploadVC.errorMessage.text = [NSString stringWithFormat: NSLocalizedString(@"%d item(s) cannot be uploaded", nil), nbItemMissing];
                         [self uploadPostItemAtIndex:itemIndex+1];
                     }
+                    item.fileData = nil;
                 }];
                 
                 [uploadTask resume];
                 
             } else {
+                item.fileData = nil;
                 item.uploadStatus = eXoItemStatusUploadFileTooLarge;
                 nbItemMissing ++;
                 uploadVC.errorMessage.text = [NSString stringWithFormat: NSLocalizedString(@"%d item(s) cannot be uploaded", nil), nbItemMissing];


### PR DESCRIPTION
- Fix bugs in share extension by free un-use memory after upload. 
- Limit the maximuns attachment to 10 items