### PR TITLE
MOB-1896 Fix bugs New Account Button (Setting VC) doen't work on iOS 7

### DIFF
--- a/Sources/Shared/UI/Settings/SettingsViewController.m
+++ b/Sources/Shared/UI/Settings/SettingsViewController.m
@@ -641,10 +641,10 @@ typedef NS_ENUM(NSInteger, SettingViewControllerSection) {
             }
             
             welcomeVC.shouldBackToSetting = YES;
-            [self dismissViewControllerAnimated:YES completion:nil];
-            [appDelegate.window.rootViewController presentViewController:welcomeVC animated:YES completion:nil];
-            [welcomeVC release];
-
+            [self dismissViewControllerAnimated:YES completion:^{
+                [appDelegate.window.rootViewController presentViewController:welcomeVC animated:YES completion:nil];
+                [welcomeVC release];
+            }];
         } else {
             ApplicationPreferencesManager *appPrefManager = [ApplicationPreferencesManager sharedInstance];
                 ServerObj* tmpServerObj = (appPrefManager.serverList)[indexPath.row];


### PR DESCRIPTION
- Fix bugs New Account Button (Setting VC) doen't work on iOS 7 
- Fix also Issue MOB-1897 New Account button in Settings does not work