### PR TITLE
MOB-1907 Fix bug truncated home screen after changing the orientation…

### DIFF
--- a/Sources/Shared/Components/eXoUtils/defines.h
+++ b/Sources/Shared/Components/eXoUtils/defines.h
@@ -63,6 +63,8 @@
 #define HTTP_PROTOCOL                       @"http://"
 #define HTTPS_PROTOCOL                       @"https://"
 
+#define SCREEN_HEIGHT UIInterfaceOrientationIsPortrait([[UIDevice currentDevice] orientation])? MAX([UIScreen mainScreen].bounds.size.width,[UIScreen mainScreen].bounds.size.height):MIN([UIScreen mainScreen].bounds.size.width,[UIScreen mainScreen].bounds.size.height)
+
 #define SCR_WIDTH_LSCP_IPAD                 1024
 #define SCR_HEIGHT_LSCP_IPAD                748
 

--- a/Sources/iPad/View Controllers/CloudSignup/Welcome/WelcomeViewController_iPad.m
+++ b/Sources/iPad/View Controllers/CloudSignup/Welcome/WelcomeViewController_iPad.m
@@ -22,6 +22,7 @@
 #import "AlreadyAccountViewController_iPad.h"
 #import "eXoNavigationController.h"
 #import "AppDelegate_iPad.h"
+#import "RootViewController.h"
 #import "defines.h"
 @interface WelcomeViewController_iPad ()
 
@@ -117,6 +118,10 @@
 - (void) didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation
 {
     scrollingLocked = NO;
+    if ([AppDelegate_iPad instance] && [AppDelegate_iPad instance].rootViewController){
+        [[AppDelegate_iPad instance].rootViewController didRotateFromInterfaceOrientation:fromInterfaceOrientation];
+    }
+
 }
 - (void)repositionSwipedElements:(UIInterfaceOrientation)toInterfaceOrientation
 {

--- a/Sources/iPad/View Controllers/File/DocumentsViewController_iPad.m
+++ b/Sources/iPad/View Controllers/File/DocumentsViewController_iPad.m
@@ -424,4 +424,12 @@
     _navigation.topItem.title = Localize(@"Documents") ;
 }
 
+#pragma mark - handle orientation
+
+-(void) didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation {
+    [super didRotateFromInterfaceOrientation:fromInterfaceOrientation];
+    [self.view setFrame:CGRectMake(self.view.frame.origin.x, 0, self.view.frame.size.width, SCREEN_HEIGHT)];
+}
+
+
 @end

--- a/Sources/iPad/View Controllers/Main/DashboardViewController_iPad.m
+++ b/Sources/iPad/View Controllers/Main/DashboardViewController_iPad.m
@@ -27,6 +27,7 @@
 #import "LanguageHelper.h"
 #import "EGOImageView.h"
 #import "RoundRectView.h"
+#import "defines.h"
 
 @implementation DashboardViewController_iPad
 
@@ -72,6 +73,11 @@
 }
 
 
+#pragma mark - handle orientation
 
+-(void) didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation {
+    [super didRotateFromInterfaceOrientation:fromInterfaceOrientation];
+    [self.view setFrame:CGRectMake(self.view.frame.origin.x, 0, self.view.frame.size.width, SCREEN_HEIGHT)];
+}
 
 @end

--- a/Sources/iPad/View Controllers/Social/ActivityStreamBrowseViewController_iPad.m
+++ b/Sources/iPad/View Controllers/Social/ActivityStreamBrowseViewController_iPad.m
@@ -219,4 +219,11 @@
     _navigation.topItem.title = Localize(@"News");
 }
 
+#pragma mark - handle orientation
+
+-(void) didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation {
+    [super didRotateFromInterfaceOrientation:fromInterfaceOrientation];
+    [self.view setFrame:CGRectMake(self.view.frame.origin.x, 0, self.view.frame.size.width, SCREEN_HEIGHT)];    
+}
+
 @end


### PR DESCRIPTION
… from Lanscape to portrait Welcome Screen (while trying to add new user).
Re-estimate the size (height) of the Home View  (Activity Stream Browser, Document VC or DashBoard VC) after finished the rotation.