### PR TITLE
MOB-1932 Fix issue: Unable to create folder on root

### DIFF
--- a/Sources/Shared/UI/Documents/DocumentsViewController.h
+++ b/Sources/Shared/UI/Documents/DocumentsViewController.h
@@ -62,7 +62,7 @@
 @property BOOL isRoot;
 
 // Check whether user can execute actions on the folder or not. 
-- (BOOL)supportActionsForItem:(File *)item ofGroup:(NSString *)driveGroup;
+- (BOOL)supportActionsForItem:(File *)item;
 
 -(void)emptyState;
 - (void)showActionSheetForPhotoAttachment;

--- a/Sources/Shared/UI/Documents/DocumentsViewController.m
+++ b/Sources/Shared/UI/Documents/DocumentsViewController.m
@@ -168,6 +168,9 @@ static NSString *PUBLIC_DRIVE = @"Public";
     }
     //And finally reload the content of the tableView
     [_tblFiles reloadData];
+
+    self.actionVisibleOnFolder = [self supportActionsForItem:_rootFile];
+    
 }
 
 // Empty State
@@ -190,29 +193,18 @@ static NSString *PUBLIC_DRIVE = @"Public";
 
 - (void)hideFileFolderActionsController {}
 
-- (BOOL)supportActionsForItem:(File *)item ofGroup:(NSString *)driveGroup {
-    /*
-     This method is installed as a workaround for bug about action buttons on drive folders. 
-     A folder is not action-able if: 
-        + Its currentFolder is empty or nil.
-     */
-    NSMutableArray *exceptDrives = [NSMutableArray array];
-    if ([driveGroup isEqualToString:PERSONAL_GROUP] && !isRoot) {
-        // For public drive of personal group, action is supported when view its detail.
-        [exceptDrives addObject:PUBLIC_DRIVE];
-    }
-    if ([item isFolder]) {
-        NSString *currentfolder = [item currentFolder];
-        if (!currentfolder || [currentfolder length] == 0) {
-            if ([exceptDrives containsObject:[item name]]) {
-                return YES;
-            }
-            return NO; 
-        } else {
-            return YES;
-        }
-    } else {
+- (BOOL)supportActionsForItem:(File *)item {
+    if (![item isFolder]) {
         // actions are always supported for files.
+        return YES;
+    }
+    // The folders at first level cannot be remove
+    NSString *currentfolder = [item currentFolder];
+    if (!currentfolder || [currentfolder length] == 0) {
+        item.canRemove = NO;
+    }
+
+    if (item && (item.name && item.name.length>0) && (item.path && item.path.length >0)) {
         return YES;
     }
     return NO;
@@ -478,8 +470,7 @@ static NSString *PUBLIC_DRIVE = @"Public";
 
     //Retrieve the correct file corresponding to the indexPath
     File *file = [_dicContentOfFolder allValues][indexPath.section][indexPath.row];
-    NSString *driveGroup = [_dicContentOfFolder allKeys][indexPath.section];
-    if ([self supportActionsForItem:file ofGroup:driveGroup]) {
+    if ([self supportActionsForItem:file]) {
         //Add action button
         UIImage *image = [UIImage imageNamed:@"DocumentDisclosureActionButton"];
         UIButton *buttonAccessory = [UIButton buttonWithType:UIButtonTypeCustom];

--- a/Sources/iPad/View Controllers/File/DocumentsViewController_iPad.m
+++ b/Sources/iPad/View Controllers/File/DocumentsViewController_iPad.m
@@ -199,8 +199,7 @@
         // Check the folder can be supported actions or not.
         if (!_rootFile) {
             // if the view is first document view.
-            NSString *driveGroup = [_dicContentOfFolder allKeys][indexPath.section];
-            newViewControllerForFilesBrowsing.actionVisibleOnFolder = [newViewControllerForFilesBrowsing supportActionsForItem:fileToBrowse ofGroup:driveGroup];
+            newViewControllerForFilesBrowsing.actionVisibleOnFolder = [newViewControllerForFilesBrowsing supportActionsForItem:fileToBrowse];
         } else {
             // support action for every folder which is not a drive.
             newViewControllerForFilesBrowsing.actionVisibleOnFolder = YES;

--- a/Sources/iPhone/View Controllers/Main/DocumentsViewController_iPhone.m
+++ b/Sources/iPhone/View Controllers/Main/DocumentsViewController_iPhone.m
@@ -174,8 +174,7 @@
         // Check the folder can be supported actions or not.
         if (!_rootFile) {
             // if the view is first document view.
-            NSString *driveGroup = [_dicContentOfFolder allKeys][indexPath.section];
-            newViewControllerForFilesBrowsing.actionVisibleOnFolder = [newViewControllerForFilesBrowsing supportActionsForItem:fileToBrowse ofGroup:driveGroup];
+            newViewControllerForFilesBrowsing.actionVisibleOnFolder = [newViewControllerForFilesBrowsing supportActionsForItem:fileToBrowse];
         } else {
             // support action for every folder which is not a drive.
             newViewControllerForFilesBrowsing.actionVisibleOnFolder = YES;


### PR DESCRIPTION
- Remove the old rules on the visible of the second Document VC. Before, Only the Public folder in Personal Group was allowed
- New Rule: Only the folders that has a Name & a URL(path) are allowed