### PR TITLE
MOB-1983 Use Relative Path for comment cell

### DIFF
--- a/Sources/Shared/Data Manager/Model/Social/SocialComment.m
+++ b/Sources/Shared/Data Manager/Model/Social/SocialComment.m
@@ -26,7 +26,7 @@
 @implementation SocialComment
 
 @synthesize text = _text;
-@synthesize identityId = _identityId; 
+@synthesize identityId = _identityId;
 @synthesize createdAt = _createdAt;
 @synthesize postedTime = _postedTime;
 @synthesize userProfile = _userProfile;
@@ -44,15 +44,15 @@
 }
 
 
-- (NSString*)fixupTextForStyledTextLabel:(NSString*)text { 
-    text = [text stringByReplacingOccurrencesOfString:@"&" withString:@"&amp;"]; 
-    return text; 
-} 
+- (NSString*)fixupTextForStyledTextLabel:(NSString*)text {
+    text = [text stringByReplacingOccurrencesOfString:@"&" withString:@"&amp;"];
+    return text;
+}
 
--(void)convertHTMLEncoding 
+-(void)convertHTMLEncoding
 {
     self.text = [self.text gtm_stringByUnescapingFromHTML];
-} 
+}
 
 -(void) parseTextHTML {
     NSRange range;
@@ -67,10 +67,11 @@
             if (!self.linkURLs){
                 self.linkURLs = [[NSMutableArray alloc] init];
             }
-            ahefTag = [self absolutePathFromStringURL:ahefTag];
-            NSURL * urlTest = [NSURL URLWithString:ahefTag];
+            NSString * absoluteHref = [self absolutePathFromStringURL:ahefTag];
+            self.text = [self.text stringByReplacingOccurrencesOfString:ahefTag withString:absoluteHref];
+            NSURL * urlTest = [NSURL URLWithString:absoluteHref];
             if (urlTest){
-                [self.linkURLs addObject:ahefTag];
+                [self.linkURLs addObject:absoluteHref];
             }
         }
         range = [htmlString rangeOfString:@"<a[^>]+href=\"" options:NSRegularExpressionSearch];
@@ -84,22 +85,22 @@
             if (!self.imageURLs){
                 self.imageURLs = [[NSMutableArray alloc] init];
             }
-            imgTag = [self absolutePathFromStringURL:imgTag];
-            NSURL * urlTest = [NSURL URLWithString:imgTag];
+            NSString * absoluteImgSrc = [self absolutePathFromStringURL:imgTag];
+            self.text = [self.text stringByReplacingOccurrencesOfString:imgTag withString:absoluteImgSrc];
+            NSURL * urlTest = [NSURL URLWithString:absoluteImgSrc];
             if (urlTest){
-                [self.imageURLs addObject:imgTag];
+                [self.imageURLs addObject:absoluteImgSrc];
             }
-
         }
         range = [htmlString rangeOfString:@"<img[^>]+src=\"" options:NSRegularExpressionSearch];
     }
- 
+    
     self.message = [self.text stringByConvertingHTMLToPlainText];
     self.cellHeight = 0;
 }
 
 -(NSString *) toHTML {
-
+    
     NSString *htmlStr = [NSString stringWithFormat:@"<html><head><style>body{background-color:transparent;color:#808080;font-family:\"Helvetica\";font-size:30pt;word-wrap: break-word;} img { width:100%%; height:auto;} div{margin-top : 60px; width:100%%; height:auto; align:center;} a:link{color: #115EAD; text-decoration: none; font-weight: bold;}</style> </head><body><div>%@</div></body></html>",self.text ? self.text : @""];
     return htmlStr;
 }

--- a/Sources/Shared/Data Manager/Proxies/Social/SocialActivityDetailsProxy.m
+++ b/Sources/Shared/Data Manager/Proxies/Social/SocialActivityDetailsProxy.m
@@ -195,6 +195,11 @@
     
     [manager getObjectsAtPath:[self createCommentsResourcePath:activityId] parameters:nil success:^(RKObjectRequestOperation *operation, RKMappingResult *mappingResult) {
         self.socialActivityDetails = [[mappingResult array] objectAtIndex:0];
+        for (SocialActivity * activity in [mappingResult array]) {
+            for (SocialComment * comment in activity.comments){
+                [comment parseTextHTML];
+            }
+        }
         [super restKitDidLoadObjects:[mappingResult array]];
     } failure:^(RKObjectRequestOperation *operation, NSError *error) {
         [super restKitDidFailWithError:error];

--- a/Sources/Shared/UI/Social/ActivityDetailViewController.m
+++ b/Sources/Shared/UI/Social/ActivityDetailViewController.m
@@ -384,9 +384,6 @@
     if (proxy == self.getCommentsProxy) {
         SocialActivity *socialActivityDetails = [(SocialActivityDetailsProxy*)proxy socialActivityDetails];
         self.socialActivity.comments = socialActivityDetails.comments;
-        for (SocialComment * comment in self.socialActivity.comments) {
-            [comment parseTextHTML];
-        }
         self.socialActivity.totalNumberOfComments = socialActivityDetails.totalNumberOfComments;
         self.getCommentsProxy = nil;
         [self.socialActivity convertToPostedTimeInWords];

--- a/share-extension/Info.plist
+++ b/share-extension/Info.plist
@@ -33,6 +33,11 @@
 	<string>2.9.20151110</string>
 	<key>LSHasLocalizedDisplayName</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/share-extension/ShareViewController.m
+++ b/share-extension/ShareViewController.m
@@ -807,9 +807,9 @@ NSMutableData * data;
         if ([postItem.type isEqualToString:@"DOC_ACTIVITY"]) {
             if (postItem.fileUploadedName!=nil && postItem.fileUploadedURL!=nil){
                 message = [NSString stringWithFormat:@"<a href=\"%@\">%@</a><br/>", postItem.fileUploadedURL, postItem.fileUploadedName];
-//                NSString * thumbnailURL = [postItem.fileUploadedURL stringByReplacingOccurrencesOfString:@"/jcr/" withString:@"/thumbnailImage/custom:/"];
+                NSURL * thumbnailURL = [NSURL URLWithString:[postItem.fileUploadedURL stringByReplacingOccurrencesOfString:@"/jcr/" withString:@"/thumbnailImage/large/"]];
                 if (postItem.isImageItem){
-                    message = [message stringByAppendingString:[NSString stringWithFormat:@"\n<img src=\"%@\" width=600px height=auto/>",postItem.fileUploadedURL]];
+                    message = [message stringByAppendingString:[NSString stringWithFormat:@"\n<img src=\"%@\" >",thumbnailURL.relativePath]];
                 }
             }
         } else if ([postItem.type isEqualToString:@"LINK_ACTIVITY"]) {
@@ -817,7 +817,7 @@ NSMutableData * data;
             if (!title || title.length ==0){
                 title = postItem.url.absoluteString;
             }
-            message = [NSString stringWithFormat:@"<a href=\"%@\">%@</a><br/>", postItem.url, title];
+            message = [NSString stringWithFormat:@"<a href=\"%@\">%@</a><br/>", postItem.url.relativePath, title];
             
         }
 


### PR DESCRIPTION
- Change post comment to use relative path for item in share extension
- Re-produit the absolute path from the relative path while parsing the social comment cell (to get URL of images && links)