### PR TITLE
Fix/mob 1917 photo picker popover 

### DIFF
--- a/Sources/Shared/Components/eXoUtils/defines.h
+++ b/Sources/Shared/Components/eXoUtils/defines.h
@@ -140,3 +140,4 @@ blue:((float)(rgbValue & 0xFF))/255.0 alpha:1.0]
 #define NUMBER_OF_ACTIVITIES 25
 #define NUMBER_OF_MORE_ACTIVITIES 25
 
+#define kIpadPopoverContentSize CGSizeMake(300,400)

--- a/Sources/Shared/UI/Documents/DocumentsViewController.h
+++ b/Sources/Shared/UI/Documents/DocumentsViewController.h
@@ -29,7 +29,7 @@
 #define kFontForMessage [UIFont fontWithName:@"Helvetica" size:13]
 #define kHeightForSectionHeader 40
 
-@interface DocumentsViewController : eXoViewController <FileActionsProtocol, FileFolderActionsProtocol, UIImagePickerControllerDelegate, UINavigationControllerDelegate, UIAlertViewDelegate, ATMHudDelegate, UITableViewDataSource, UITableViewDelegate, UIActionSheetDelegate, UIPopoverControllerDelegate, FilesProxyDelegate> {
+@interface DocumentsViewController : eXoViewController <FileActionsProtocol, FileFolderActionsProtocol, UIImagePickerControllerDelegate, UINavigationControllerDelegate, UIAlertViewDelegate, ATMHudDelegate, UITableViewDataSource, UITableViewDelegate, UIActionSheetDelegate, UIPopoverControllerDelegate, FilesProxyDelegate, WEPopoverControllerDelegate> {
     
     File *_rootFile;
     
@@ -48,7 +48,7 @@
     
     UITableViewCell *_currentCell;
     
-    UIPopoverController *_popoverPhotoLibraryController;
+    WEPopoverController *_popoverPhotoLibraryController;
     
     BOOL isRoot;
     BOOL stop;
@@ -56,7 +56,7 @@
 
 // Follow the Apple convention, the child view should keep a weak reference to parent only.
 @property(nonatomic, assign) DocumentsViewController *parentController;
-@property(nonatomic, retain) UIPopoverController *popoverPhotoLibraryController;
+@property(nonatomic, retain) WEPopoverController *popoverPhotoLibraryController;
 @property (nonatomic, assign) BOOL actionVisibleOnFolder;
 @property (nonatomic, retain) File * fileToApplyAction;
 @property BOOL isRoot;

--- a/Sources/Shared/UI/Documents/DocumentsViewController.m
+++ b/Sources/Shared/UI/Documents/DocumentsViewController.m
@@ -700,18 +700,15 @@ static NSString *PUBLIC_DRIVE = @"Public";
             thePicker.modalTransitionStyle = UIModalTransitionStyleCrossDissolve;
             thePicker.modalPresentationStyle = UIModalPresentationFormSheet;
             
-            self.popoverPhotoLibraryController = [[UIPopoverController alloc] initWithContentViewController:thePicker];
+            self.popoverPhotoLibraryController = [[WEPopoverController alloc] initWithContentViewController:thePicker];
+            thePicker.preferredContentSize = kIpadPopoverContentSize;
             self.popoverPhotoLibraryController.delegate = self;
-            [self.popoverPhotoLibraryController setPopoverContentSize:CGSizeMake(320, 320) animated:YES];
-            
 
             if(displayActionDialogAtRect.size.width == 0) {
-                
                 //present the popover from the rightBarButtonItem of the navigationBar
                 [self.popoverPhotoLibraryController presentPopoverFromBarButtonItem:_navigation.topItem.rightBarButtonItem 
                                                  permittedArrowDirections:UIPopoverArrowDirectionUp 
                                                                  animated:YES];
-             
 
             }
             else {
@@ -961,7 +958,7 @@ static NSString *PUBLIC_DRIVE = @"Public";
 }
 
 #pragma mark - ActionSheet Delegate
-- (void)actionSheet:(UIActionSheet *)actionSheet clickedButtonAtIndex:(NSInteger)buttonIndex
+- (void)actionSheet:(UIActionSheet *)actionSheet didDismissWithButtonIndex:(NSInteger)buttonIndex
 {
     if(buttonIndex < 2 && buttonIndex >=0)
     {

--- a/Sources/Shared/UI/Social/MessageComposerViewController.m
+++ b/Sources/Shared/UI/Social/MessageComposerViewController.m
@@ -648,47 +648,21 @@
 // i.e. user chooses an image for the 1st time
 - (void) imagePickerController:(UIImagePickerController *)picker didFinishPickingMediaWithInfo:(NSDictionary *)info
 {
-    ImagePreviewViewController *imagePreview = [[ImagePreviewViewController alloc] initWithNibName:@"ImagePreviewViewController" bundle:nil];
-    __block __typeof__(imagePreview) bImagePreview = imagePreview; // create a weak reference to avoid retain cycle.
-    [imagePreview changeImageWithCompletion:^(void) {
-        // called when the user has chosen a photo and decides to change it (tap Change)
-        // remove image preview from nav bar to back to image picker.
-        [bImagePreview.navigationController popViewControllerAnimated:YES];
-    }];
-    [imagePreview removeImageWithCompletion:^(void) {
-        // called when the user has chosen a photo and decides to remove it (tap Remove)
-        // remove image in self view and dismiss image picker to back to self view.
-        self.attPhotoView.image = nil;
-        if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
-            [self._popoverPhotoLibraryController dismissPopoverAnimated:YES];
-            self._popoverPhotoLibraryController = nil;
-            [self reArrangeSubViews]; // rearrange the view to update the photo view.
-        } else {
-            // restore previous status bar
-            [[UIApplication sharedApplication] setStatusBarStyle:_previousStatusBarStyle];
-            [[UIApplication sharedApplication] setStatusBarHidden:_previousStatusBarHidden];
-            [self dismissViewControllerAnimated:YES completion:nil];
-        }
-    }];
-    [imagePreview selectImageWithCompletion:^(void) {
-        // called when the user has chosen a photo and decides to keep it (tap OK)
-        // add photo to the self view and come back to such view.
-        [self addPhotoToView:[self resizeImage:bImagePreview.imageView.image]];
-        if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
-            [self._popoverPhotoLibraryController dismissPopoverAnimated:YES];
-            self._popoverPhotoLibraryController = nil;
-        } else {
-            // restore previous status bar
-            [[UIApplication sharedApplication] setStatusBarStyle:_previousStatusBarStyle];
-            [[UIApplication sharedApplication] setStatusBarHidden:_previousStatusBarHidden];
-            self.navigationController.toolbarHidden = YES;
-            [self dismissViewControllerAnimated:YES completion:nil];
-        }
-    }];
+
+    [self addPhotoToView:[self resizeImage:info[UIImagePickerControllerOriginalImage]]];
+    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+        [self._popoverPhotoLibraryController dismissPopoverAnimated:YES];
+        self._popoverPhotoLibraryController = nil;
+    } else {
+        // restore previous status bar
+        [[UIApplication sharedApplication] setStatusBarStyle:_previousStatusBarStyle];
+        [[UIApplication sharedApplication] setStatusBarHidden:_previousStatusBarHidden];
+        self.navigationController.toolbarHidden = YES;
+        [self dismissViewControllerAnimated:YES completion:nil];
+    }
+
     [[UIApplication sharedApplication] setStatusBarStyle:_previousStatusBarStyle];
     [[UIApplication sharedApplication] setStatusBarHidden:_previousStatusBarHidden];
-    [picker pushViewController:imagePreview animated:YES];
-    [imagePreview displayImage:[self resizeImage:info[UIImagePickerControllerOriginalImage]]];
 }
 
 

--- a/Sources/Shared/UI/SpaceTableViewCell.xib
+++ b/Sources/Shared/UI/SpaceTableViewCell.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6751" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6736"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -15,32 +15,32 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="saj-LP-fzW" customClass="EGOImageView">
-                        <rect key="frame" x="35" y="4" width="35" height="35"/>
+                        <rect key="frame" x="36" y="4" width="35" height="35"/>
+                        <animations/>
                         <constraints>
                             <constraint firstAttribute="height" constant="35" id="hd3-qg-TcH"/>
                             <constraint firstAttribute="width" constant="35" id="uvo-GA-XzQ"/>
                         </constraints>
                     </imageView>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="To:" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="22" translatesAutoresizingMaskIntoConstraints="NO" id="aEU-ds-p96">
-                        <rect key="frame" x="5" y="11" width="22" height="21"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="21" id="4Dn-Lc-gXt"/>
-                            <constraint firstAttribute="width" relation="lessThanOrEqual" constant="55" id="fdw-Yk-XFU"/>
-                        </constraints>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="To:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="22" translatesAutoresizingMaskIntoConstraints="NO" id="aEU-ds-p96">
+                        <rect key="frame" x="5" y="12" width="23" height="20"/>
+                        <animations/>
                         <fontDescription key="fontDescription" type="system" pointSize="16"/>
                         <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Space Name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UKS-aI-BWg">
-                        <rect key="frame" x="81" y="11" width="99" height="21"/>
+                        <rect key="frame" x="82" y="11" width="98" height="21"/>
+                        <animations/>
                         <constraints>
                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="70" id="bem-eP-jyS"/>
                         </constraints>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                        <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
                 </subviews>
+                <animations/>
                 <constraints>
                     <constraint firstAttribute="centerY" secondItem="saj-LP-fzW" secondAttribute="centerY" id="490-2R-jNQ"/>
                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="UKS-aI-BWg" secondAttribute="trailing" constant="5" id="6tB-Me-nWT"/>
@@ -52,6 +52,7 @@
                     <constraint firstItem="saj-LP-fzW" firstAttribute="leading" secondItem="aEU-ds-p96" secondAttribute="trailing" constant="8" id="slb-yO-eTm"/>
                 </constraints>
             </tableViewCellContentView>
+            <animations/>
             <connections>
                 <outlet property="prefixLabel" destination="aEU-ds-p96" id="ruW-Ld-RYt"/>
                 <outlet property="spaceAvatar" destination="saj-LP-fzW" id="Wr2-7V-sJ7"/>
@@ -60,9 +61,4 @@
             <point key="canvasLocation" x="100" y="208"/>
         </tableViewCell>
     </objects>
-    <simulatedMetricsContainer key="defaultSimulatedMetrics">
-        <simulatedStatusBarMetrics key="statusBar"/>
-        <simulatedOrientationMetrics key="orientation"/>
-        <simulatedScreenMetrics key="destination" type="retina4"/>
-    </simulatedMetricsContainer>
 </document>

--- a/Sources/iPad/View Controllers/File/DocumentsViewController_iPad.h
+++ b/Sources/iPad/View Controllers/File/DocumentsViewController_iPad.h
@@ -30,7 +30,7 @@
 @interface DocumentsViewController_iPad : DocumentsViewController <UIPopoverControllerDelegate,WEPopoverControllerDelegate>
 {    
     WEPopoverController *_actionPopoverController;
-    UIPopoverController *_fileFolderActionsPopoverController;
+    WEPopoverController *_fileFolderActionsPopoverController;
 }
 
 - (void)dismissAddPhotoPopOver:(BOOL)animation;

--- a/Sources/iPad/View Controllers/Social/MessageComposerViewController_iPad.m
+++ b/Sources/iPad/View Controllers/Social/MessageComposerViewController_iPad.m
@@ -32,11 +32,6 @@
     return YES;
 }
 
-- (void)didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation
-{
-    [_popoverPhotoLibraryController dismissPopoverAnimated:YES];
-}
-
 - (void)updateHudPosition {
     self.hudLoadWaiting.center = CGPointMake(self.view.center.x, self.view.center.y-70);
 }

--- a/Sources/iPhone/View Controllers/Main/DocumentsViewController_iPhone.m
+++ b/Sources/iPhone/View Controllers/Main/DocumentsViewController_iPhone.m
@@ -285,7 +285,6 @@
     
     CGRect frame = CGRectMake(290,-5, 0, 0);
     [self.popoverClass presentPopoverFromRect:frame inView:self.view permittedArrowDirections:UIPopoverArrowDirectionUp animated:YES];
-    [AppDelegate_iPhone instance].homeSidebarViewController_iPhone.contentNavigationBar.topItem.rightBarButtonItem.enabled = NO;
 }
 
 -(void)askToMakeFolderActions:(BOOL)createNewFolder {


### PR DESCRIPTION
- On iPad: replace the UIPopover by WEPopover for a better support in rotation & the same appearance as file actions popopver (WEPopover is using for this actions)

- Remove the Image Preview after a photo is selected:
  + We don't need a seconde confirmation, user is asked 1 time before while selecting the photo
  + The user can always open the preview in tapping on the Image View (of the message composer view)